### PR TITLE
Allow validate array entries

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ function validateLine(entry, data, index = null) {
   if (data && !AvailableTypes[entry.type](data))
     throw new ValidateException(
       `Field ${entry.name} with value ${data}, is not typeof ${entry.type}${
-        index ? ` - on index #${index}` : ''
+        typeof index !== 'undefined' ? ` - on index #${index}` : ''
       }!`
     );
 
@@ -60,13 +60,11 @@ function _validate(input, dto, index = null) {
 
   const requiredProps = dto.filter((d) => d.required).map((d) => d.name);
 
-  console.log(requiredProps, keys)
-
   requiredProps.forEach((prop) => {
     if (!keys.includes(prop)) {
       throw new ValidateException(
         `Field ${prop} is required${
-          index ? ` - on index #${index}` : ''
+          typeof index !== 'undefined' ? ` - on index #${index}` : ''
         }!`
       );
     }
@@ -114,7 +112,6 @@ module.exports = {
         }
 
         if (input instanceof Array) {
-          console.log('ne')
           result = input.map((row, idx) => _validate(row, dto, idx));
         }
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -234,7 +234,7 @@ describe('nodejs-dto', () => {
 
   })
 
-  it ('should validate an array, and throws an because are missing Age on index 0', () => {
+  it ('should validate an array, and throws an because are missing Age on index #1', () => {
     const dto = MakeDto([
       {
         name: 'Age',
@@ -252,12 +252,13 @@ describe('nodejs-dto', () => {
 
     expect(() => dto.validate([
       {
+        Age: 12,
         Name: 'John Doe'
       },
       {
         Name: 'Jhon Doe'
       }
-    ])).to.throw('Field Age is required - on index #0!')
+    ])).to.throw('Field Age is required - on index #1!')
 
   })
 });


### PR DESCRIPTION
Given an entry of array, the method `validate` need to accept an array entry and validate in the same way that is using to validate an object.

When throws an error, lib explain what index have error.

```js


const dto = MakeDto([
  {
    name: 'Age',
    serialize: 'age',
    type: 'Number',
    required: true,
  },
]);

dto.validate({
  Age: '123'
})

```